### PR TITLE
 Fix: Display correct town building icons in Intel tab

### DIFF
--- a/src/assets/styles/icons.scss
+++ b/src/assets/styles/icons.scss
@@ -96,27 +96,27 @@
   background: url(../images/game/buildings_sprite_40x40.png) no-repeat 0 0;
   border: .5px solid #724b08;
 }
-.building_icon40x40.academy { background-position: 0 0; }
-.building_icon40x40.barracks { background-position: -40px 0; }
-.building_icon40x40.docks { background-position: -80px 0; }
-.building_icon40x40.farm { background-position: -120px 0; }
-.building_icon40x40.hide { background-position: -160px 0; }
-.building_icon40x40.ironer { background-position: -200px 0; }
-.building_icon40x40.library { background-position: -240px 0; }
-.building_icon40x40.lighthouse { background-position: -280px 0; }
-.building_icon40x40.lumber { background-position: -320px 0; }
-.building_icon40x40.main { background-position: -360px 0; }
-.building_icon40x40.market { background-position: 0 -40px; }
-.building_icon40x40.oracle { background-position: -40px -40px; }
-.building_icon40x40.place { background-position: -80px -40px; }
-.building_icon40x40.statue { background-position: -120px -40px; }
-.building_icon40x40.stoner { background-position: -160px -40px; }
-.building_icon40x40.storage { background-position: -200px -40px; }
-.building_icon40x40.temple { background-position: -240px -40px; }
-.building_icon40x40.theater { background-position: -280px -40px; }
-.building_icon40x40.thermal { background-position: -320px -40px; }
-.building_icon40x40.tower { background-position: -360px -40px; }
-.building_icon40x40.trade_office { background-position: 0 -80px; }
+.building_icon40x40.ding_academy { background-position: 0 0; }
+.building_icon40x40.ding_barracks { background-position: -40px 0; }
+.building_icon40x40.ding_docks { background-position: -80px 0; }
+.building_icon40x40.ding_farm { background-position: -120px 0; }
+.building_icon40x40.ding_hide { background-position: -160px 0; }
+.building_icon40x40.ding_ironer { background-position: -200px 0; }
+.building_icon40x40.ding_library { background-position: -240px 0; }
+.building_icon40x40.ding_lighthouse { background-position: -280px 0; }
+.building_icon40x40.ding_lumber { background-position: -320px 0; }
+.building_icon40x40.ding_main { background-position: -360px 0; }
+.building_icon40x40.ding_market { background-position: 0 -40px; }
+.building_icon40x40.ding_oracle { background-position: -40px -40px; }
+.building_icon40x40.ding_place { background-position: -80px -40px; }
+.building_icon40x40.ding_statue { background-position: -120px -40px; }
+.building_icon40x40.ding_stoner { background-position: -160px -40px; }
+.building_icon40x40.ding_storage { background-position: -200px -40px; }
+.building_icon40x40.ding_temple { background-position: -240px -40px; }
+.building_icon40x40.ding_theater { background-position: -280px -40px; }
+.building_icon40x40.ding_thermal { background-position: -320px -40px; }
+.building_icon40x40.ding_tower { background-position: -360px -40px; }
+.building_icon40x40.ding_trade_office { background-position: 0 -80px; }
 .building_icon40x40.wall { background-position: -40px -80px; }
 
 .hero40x40,


### PR DESCRIPTION
Previously, all town buildings in the Intel tab were displaying the same placeholder icon (academy).
This update corrects the issue by rendering the appropriate icon for each building based on its type.

Before:
All buildings shared a single, incorrect icon.
![Screenshot_19](https://github.com/user-attachments/assets/a77958e6-cda2-4bad-855e-32ea0d5e08e4)

After:
Each building now displays its correct, corresponding icon.
![Screenshot_18](https://github.com/user-attachments/assets/cf76bdb0-3945-41c8-8e72-6798ce8f8f8d)


Let me know if further adjustments or tests are needed!